### PR TITLE
only save dirty attributes to prevent unnecessary model events

### DIFF
--- a/src/Console/GenerateComputedAttributes.php
+++ b/src/Console/GenerateComputedAttributes.php
@@ -89,7 +89,9 @@ class GenerateComputedAttributes extends Command
                             foreach ($attributes as $attribute) {
                                 $modelResult->setComputedAttributeValue($attribute);
                             }
-                            $modelResult->save();
+                            if ($modelResult->isDirty()) {
+                                $modelResult->save();
+                            }
                         }
                     });
             }

--- a/tests/TestEnvironment/Events/PostSaved.php
+++ b/tests/TestEnvironment/Events/PostSaved.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Korridor\LaravelComputedAttributes\Tests\TestEnvironment\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PostSaved
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+}

--- a/tests/TestEnvironment/Events/PostSaving.php
+++ b/tests/TestEnvironment/Events/PostSaving.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Korridor\LaravelComputedAttributes\Tests\TestEnvironment\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PostSaving
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+}

--- a/tests/TestEnvironment/Models/Post.php
+++ b/tests/TestEnvironment/Models/Post.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Korridor\LaravelComputedAttributes\ComputedAttributes;
+use Korridor\LaravelComputedAttributes\Tests\TestEnvironment\Events\PostSaved;
+use Korridor\LaravelComputedAttributes\Tests\TestEnvironment\Events\PostSaving;
 
 class Post extends Model
 {
@@ -30,6 +32,14 @@ class Post extends Model
     protected $casts = [
         'complex_calculation' => 'int',
         'sum_of_votes' => 'int',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $dispatchesEvents = [
+        'saved' => PostSaved::class,
+        'saving' => PostSaving::class,
     ];
 
     /*


### PR DESCRIPTION
improve performance by not saving dirty models in generate computed attributes command