### PR TITLE
Update varToString return statement to handle enum values

### DIFF
--- a/src/Console/ValidateComputedAttributes.php
+++ b/src/Console/ValidateComputedAttributes.php
@@ -166,6 +166,6 @@ class ValidateComputedAttributes extends Command
             return 'null';
         }
 
-        return gettype($var) . '(' . $var . ')';
+        return gettype($var) . '(' . ($var->value ?? $var) . ')';
     }
 }


### PR DESCRIPTION
Enums may not cast to strings without a fight